### PR TITLE
Add a function to wrap a buffer in a datagram

### DIFF
--- a/serial_datagram_buffer_writer.c
+++ b/serial_datagram_buffer_writer.c
@@ -1,3 +1,4 @@
+#include "serial_datagram.h"
 #include "serial_datagram_buffer_writer.h"
 
 
@@ -8,7 +9,7 @@ void serial_datagram_buffer_writer_init(serial_datagram_buffer_writer_t *writer,
     writer->write_index = 0;
 }
 
-void serial_datagram_buffer_writer_cb(void *arg, void *buffer, size_t len)
+void serial_datagram_buffer_writer_cb(void *arg, const void *buffer, size_t len)
 {
     size_t i;
     serial_datagram_buffer_writer_t *writer = (serial_datagram_buffer_writer_t *)arg;
@@ -22,3 +23,14 @@ void serial_datagram_buffer_writer_cb(void *arg, void *buffer, size_t len)
     }
 }
 
+size_t serial_datagram_buffer_wrap(uint8_t *input_buffer, size_t input_buffer_len,
+                                   uint8_t *output_buffer, size_t output_buffer_len)
+{
+    serial_datagram_buffer_writer_t writer;
+    serial_datagram_buffer_writer_init(&writer, output_buffer, output_buffer_len);
+
+    serial_datagram_send((void *)input_buffer, input_buffer_len,
+                         serial_datagram_buffer_writer_cb, (void *)&writer);
+
+    return writer.write_index;
+}

--- a/serial_datagram_buffer_writer.h
+++ b/serial_datagram_buffer_writer.h
@@ -17,7 +17,14 @@ typedef struct {
 
 void serial_datagram_buffer_writer_init(serial_datagram_buffer_writer_t *writer, uint8_t *buffer, size_t buffer_size);
 
-void serial_datagram_buffer_writer_cb(void *arg, void *buffer, size_t len);
+void serial_datagram_buffer_writer_cb(void *arg, const void *buffer, size_t len);
+
+/** @brief Wraps a buffer in a datagram.
+ *
+ * @return Length of the datagram
+ */
+size_t serial_datagram_buffer_wrap(uint8_t *input_buffer, size_t input_buffer_len,
+                                   uint8_t *output_buffer, size_t output_buffer_len);
 
 #ifdef __cplusplus
 }

--- a/tests/serial_datagram_buffer_writer_tests.cpp
+++ b/tests/serial_datagram_buffer_writer_tests.cpp
@@ -11,6 +11,7 @@ TEST_GROUP(SerialDatagramBuffferWriterTestCase)
 
     void setup(void)
     {
+        memset(&buffer, 0, sizeof buffer);
         serial_datagram_buffer_writer_init(&writer, buffer, sizeof buffer);
     }
 };
@@ -43,6 +44,17 @@ TEST(SerialDatagramBuffferWriterTestCase, DoesntOverflow)
     BYTES_EQUAL('h', smallbuf[0]);
     BYTES_EQUAL('e', smallbuf[1]);
     BYTES_EQUAL(0x55, smallbuf[2]);
+}
+
+TEST(SerialDatagramBuffferWriterTestCase, CanWrapBuffer)
+{
+    uint8_t data[] = "hello";
+    size_t ret;
+
+    ret = serial_datagram_buffer_wrap(data, sizeof data, buffer, sizeof buffer);
+
+    BYTES_EQUAL(0xc0, buffer[10]);
+    CHECK_EQUAL(sizeof data + sizeof(uint32_t) + 1, ret); // data + crc32 + end
 }
 
 


### PR DESCRIPTION
This is useful if we need the whole datagram to be ready at once, for
example when working over a TCP/IP link.