### PR TITLE
fix failing unit tests & CRC check with python2

### DIFF
--- a/python/serial_datagram.py
+++ b/python/serial_datagram.py
@@ -43,7 +43,7 @@ def decode(data):
     data = data.replace(ESC + ESC_ESC, ESC)
 
     expected_crc = struct.unpack('>I', data[-4:])[0]
-    actual_crc = crc32(data[:-4])
+    actual_crc = crc32(data[:-4]) & 0xffffffff
 
     if expected_crc != actual_crc:
         raise CRCMismatchError

--- a/python/tests/test_serial_datagram.py
+++ b/python/tests/test_serial_datagram.py
@@ -8,7 +8,7 @@ class UARTDatagramEncodeTestCase(unittest.TestCase):
         """
         Checks that the CRC is correctly encapsulated at the end of the datagram.
         """
-        data = bytes([0] * 3)
+        data = b'\x00' * 3
         expected_crc = struct.pack('>I', 4282505490)
 
         datagram = serial_datagram.encode(data)
@@ -18,17 +18,17 @@ class UARTDatagramEncodeTestCase(unittest.TestCase):
         """
         Checks that the end marker is added.
         """
-        data = bytes([0] * 3)
+        data = b'\x00' * 3
         datagram = serial_datagram.encode(data)
-        self.assertEqual(0xc0, datagram[-1], "No end marker")
+        self.assertEqual(b'\xc0', datagram[-1:], "No end marker")
 
     def test_end_is_replaced(self):
         """
         Checks that the end byte is escaped.
         """
-        data = bytes([0xc0]) # end marker is 0xDB
+        data = b'\xC0'  # end marker is 0xC0
         datagram = serial_datagram.encode(data)
-        expected = bytes([0xdb, 0xdc]) # transposed end
+        expected = b'\xDB\xDC'  # transposed end
 
         self.assertEqual(expected, datagram[0:2], "END was not correctly escaped")
 
@@ -36,10 +36,9 @@ class UARTDatagramEncodeTestCase(unittest.TestCase):
         """
         Checks that the ESC byte is escaped.
         """
-
-        data = bytes([0xdb]) # esc marker
+        data = b'\xDB' # esc marker
         datagram = serial_datagram.encode(data)
-        expected = bytes([0xdb, 0xdd]) # transposed esc
+        expected = b'\xDB\xDD'  # transposed esc
         self.assertEqual(expected, datagram[0:2], "ESC was not correctly escaped")
 
 class UARTDatagramDecodeTestCase(unittest.TestCase):
@@ -47,17 +46,16 @@ class UARTDatagramDecodeTestCase(unittest.TestCase):
         """
         Simply tries to decode a complete datagram.
         """
-        datagram = [0,0,0,0xff,0x41,0xd9, 0x12, 0xC0]
+        datagram = b'\x00\x00\x00\xFF\x41\xD9\x12\xC0'
         datagram = bytes(datagram)
         datagram = serial_datagram.decode(datagram)
-        self.assertEqual(bytes([0,0,0]), datagram)
+        self.assertEqual(b'\x00\x00\x00', datagram)
 
     def test_invalid_crc_raises_exception(self):
         """
         Checks that having a wrong crc raises an exception.
         """
-        datagram = [0,0,0,0xde, 0xad, 0xde, 0xad, 0xC0]
-        datagram = bytes(datagram)
+        datagram = b'\x00\x00\x00\xDE\xAD\xDE\xAD\xC0'
         with self.assertRaises(serial_datagram.CRCMismatchError):
             serial_datagram.decode(datagram)
 
@@ -65,16 +63,16 @@ class UARTDatagramDecodeTestCase(unittest.TestCase):
         """
         Checks that ESC + ESC_ESC is transformed to ESC.
         """
-        datagram = b'\xdb\xdd\xc3\x03\xe4\xd1\xc0'
+        datagram = b'\xDB\xDD\xC3\x03\xE4\xD1\xC0'
         datagram = serial_datagram.decode(datagram)
-        self.assertEqual(bytes([0xdb]), datagram)
+        self.assertEqual(b'\xDB', datagram)
 
     def test_end_is_unsescaped(self):
         """
         Checks that ESC + ESC_END is transformed to END.
         """
         datagram = serial_datagram.decode(b'\xdb\xdcIf-=\xc0')
-        self.assertEqual(bytes([0xc0]), datagram)
+        self.assertEqual(b'\xC0', datagram)
 
     def test_that_weird_sequences_work(self):
         """
@@ -93,7 +91,7 @@ class UARTDatagramDecodeTestCase(unittest.TestCase):
         """
 
         with self.assertRaises(serial_datagram.FrameError):
-            serial_datagram.decode(bytes([1,2,3,3]))
+            serial_datagram.decode(b'\x01\x02\x03\x03')
 
 
 class ReadDatagramTestCase(unittest.TestCase):
@@ -101,15 +99,15 @@ class ReadDatagramTestCase(unittest.TestCase):
         """
         Checks if we can read a whole datagram.
         """
-        fd = BytesIO(serial_datagram.encode(bytes([1,2,3])))
+        fd = BytesIO(serial_datagram.encode(b'\x01\x02\x03'))
         dt = serial_datagram.read(fd)
-        self.assertEqual(dt, bytes([1,2,3]))
+        self.assertEqual(dt, b'\x01\x02\x03')
 
     def test_what_happens_if_timeout(self):
         """
         Checks that we return None if there was a timeout.
         """
-        data = serial_datagram.encode(bytes([1,2,3]))
+        data = serial_datagram.encode(b'\x01\x02\x03')
 
         # Introduce a timeout before receiving the last byte
         fd = BytesIO(data[:-1])


### PR DESCRIPTION
- CRC calculation in decode function
- unit test problems with `bytes` type in python2